### PR TITLE
添加读取linux下系统字体脚本

### DIFF
--- a/src/main_modules/getFonts.js
+++ b/src/main_modules/getFonts.js
@@ -26,9 +26,34 @@ function winGetFonts() {
   });
 }
 
-// 等待有缘人提pr
 function linuxGetFonts() {
-  return Promise.resolve(["当前系统不受支持"]);
+  return new Promise((res, rej) => {
+    exec(
+      `fc-list | grep -oP "(?<=: ).*?(?=:)"`,
+      {
+        shell: "/bin/sh",
+        encoding: "utf8",
+      },
+      (err, stdout, stderr) => {
+        if (err) {
+          rej(err);
+        }
+        if (stderr) {
+          rej(stderr);
+        }
+        const fontList = stdout.split("\n").filter(v => v.trim());
+        const uniqueFontList = [];
+        const seen = new Set();
+        fontList.forEach((v) => {
+          if (!seen.has(v)) {
+            seen.add(v);
+            uniqueFontList.push(v);
+          }
+        })
+        res(uniqueFontList);
+      },
+    );
+  });
 }
 
 // 等待有缘人提pr


### PR DESCRIPTION
在 linux 平台使用 `fc-list` 命令获取字体列表（主流发行版均自带 Fontconfig 包，支持该命令）

使用 `fc-list | grep -oP "(?<=: ).*?(?=:)"` 匹配出 family name，并去重