### PR TITLE
Replace chcp with pure powershell to set output encoding on Windows

### DIFF
--- a/src/main_modules/getFonts.js
+++ b/src/main_modules/getFonts.js
@@ -2,9 +2,7 @@ const { exec } = require("node:child_process");
 function winGetFonts() {
   return new Promise((res, rej) => {
     exec(
-      `if([System.Text.Encoding]::Default.WindowsCodePage -eq 65001){
-         chcp 65001;
-      }
+      `[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
       [System.Reflection.Assembly]::LoadWithPartialName("System.Drawing");
       (New-Object System.Drawing.Text.InstalledFontCollection).Families;`,
       {

--- a/src/main_modules/getFonts.js
+++ b/src/main_modules/getFonts.js
@@ -2,7 +2,9 @@ const { exec } = require("node:child_process");
 function winGetFonts() {
   return new Promise((res, rej) => {
     exec(
-      `chcp 65001;
+      `if([System.Text.Encoding]::Default.WindowsCodePage -eq 65001){
+         chcp 65001;
+      }
       [System.Reflection.Assembly]::LoadWithPartialName("System.Drawing");
       (New-Object System.Drawing.Text.InstalledFontCollection).Families;`,
       {


### PR DESCRIPTION
<del>不确定正确，有待测试</del>
大概率正确