### PR TITLE
打开"消息列表只显示头像"功能时 移除群助手标题栏中文字使布局更和谐

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -887,6 +887,9 @@
   padding: 0 !important;
   gap: 0 !important;
 }
+.message-panel .two-col-layout__aside.only-avatar .list-toggler .group-assistent-list .group-assistent-list__top .list-back + span {
+  display: none !important;
+}
 .message-panel .two-col-layout__aside.only-avatar .list-toggler .viewport-list .list-item {
   border-radius: 0 !important;
   position: relative;

--- a/src/global.scss
+++ b/src/global.scss
@@ -949,6 +949,9 @@
         padding: 0 !important;
         gap: 0 !important;
       }
+      .group-assistent-list .group-assistent-list__top .list-back + span {
+        display: none !important;
+      }
       .viewport-list {
         .list-item {
           border-radius: 0 !important;


### PR DESCRIPTION
移除前：
![bb9f645bd1cd478a376f80b05387d89](https://github.com/xiyuesaves/LiteLoaderQQNT-lite_tools/assets/29279979/f9f0a8e9-34fa-4491-bad8-4fc0bf74fe28)
移除后：
![image](https://github.com/xiyuesaves/LiteLoaderQQNT-lite_tools/assets/29279979/64ce6e0e-918a-4f48-b658-51041c207354)
