### PR TITLE
在本地表情右键菜单中增加 设为分组图标 功能

### DIFF
--- a/src/preload.js
+++ b/src/preload.js
@@ -73,6 +73,8 @@ contextBridge.exposeInMainWorld("lite_tools", {
   saveBase64ToFile: (...args) => ipcRenderer.send("LiteLoader.lite_tools.saveBase64ToFile", ...args),
   // 从历史记录中移除指定文件
   deleteCommonlyEmoticons: (path) => ipcRenderer.send("LiteLoader.lite_tools.deleteCommonlyEmoticons", path),
+  // 设为分组图标
+  setEmoticonsIcon: (path) => ipcRenderer.send("LiteLoader.lite_tools.setEmoticonsIcon", path),
   // 关键字提醒
   onKeywordReminder: (callback) => ipcRenderer.on("LiteLoader.lite_tools.onKeywordReminder", callback),
   // 复制文件

--- a/src/render_modules/HTMLtemplate.js
+++ b/src/render_modules/HTMLtemplate.js
@@ -60,6 +60,9 @@ const localEmoticonsHTML = `<div class="full-screen-preview">
     <a class="context-menu-item open-file">
       <span class="context-menu-item__text">图片查看器打开</span>
     </a>
+    <a class="context-menu-item set-icon">
+      <span class="context-menu-item__text">设为分组图标</span>
+    </a>
     <a class="context-menu-item context-danger delete-file">
       <span class="context-menu-item__text">从文件夹中删除</span>
     </a>

--- a/src/render_modules/localEmoticons.js
+++ b/src/render_modules/localEmoticons.js
@@ -655,6 +655,11 @@ function loadDom() {
     lite_tools.deleteCommonlyEmoticons(targetElement.path);
     closeContextMenu();
   });
+  contextMenuEl.querySelector(".set-icon").addEventListener("click", () => {
+    log("设为分组图标", targetElement.path);
+    lite_tools.setEmoticonsIcon(targetElement.path);
+    closeContextMenu();
+  });
   contextMenuEl.querySelector(".delete-file").addEventListener("click", async () => {
     log("从文件中删除", targetElement.path);
     const res = await lite_tools.deleteEmoticonsFile(targetElement.path);
@@ -761,8 +766,10 @@ function contextMenu(event) {
 
   if (targetElement.type === "commonly") {
     contextMenuEl.querySelector(".delete-from-commonly").classList.remove("hide");
+    contextMenuEl.querySelector(".set-icon").classList.add("hide");
   } else {
     contextMenuEl.querySelector(".delete-from-commonly").classList.add("hide");
+    contextMenuEl.querySelector(".set-icon").classList.remove("hide");
   }
 
   let offsetTop =


### PR DESCRIPTION
可以直接通过点击表情的右键菜单将其设置为表情包分组的封面。
不对历史表情页生效