### PR TITLE
最近使用分组前置

### DIFF
--- a/src/config/configTemplate.json
+++ b/src/config/configTemplate.json
@@ -33,6 +33,7 @@
     "toLeftSlot": false,
     "hoverShowCommonlyEmoticons": false,
     "commonlyNum": 20,
+    "recentlyNum": 0,
     "rowsSize": 5,
     "ffmpegPath": "",
     "tgsToGifPath": "",

--- a/src/config/localEmoticonsConfigTemplate.json
+++ b/src/config/localEmoticonsConfigTemplate.json
@@ -1,3 +1,4 @@
 {
-  "commonlyEmoticons": []
+  "commonlyEmoticons": [],
+  "recentFolders": []
 }

--- a/src/html/view.html
+++ b/src/html/view.html
@@ -686,7 +686,14 @@
       <li class="vertical-list-item">
         <div>
           <h2>最近使用分组前置</h2>
-          <span class="secondary-text recommend-num">将最近使用过的指定数量表情分组前置，-1为无限制，0为关闭功能（默认关闭）</span>
+          <span class="secondary-text recommend-num">
+            将最近使用过的指定数量表情分组前置<br />
+            <strong>1-正无穷</strong> 将到此数字的表情分组设置为按最近使用排序<br />
+            <strong>0</strong> 禁用<br />
+            <strong>-1</strong> 无限制<br />
+            <strong>-2</strong> 锁定当前排序<br />
+            <i>这里的说明可能不太通俗易懂，如果有更好的描述欢迎提: <a class="link" data-href="https://github.com/xiyuesaves/LiteLoaderQQNT-lite_tools/pulls">Pr</a></i>
+          </span>
         </div>
         <div class="slot-input-box">
           <input placeholder="0" class="slot-input recent-folders-num text_color" type="number" spellcheck="false" />
@@ -1130,7 +1137,9 @@
       <li class="vertical-list-item">
         <div>
           <h2>FFmpeg路径地址</h2>
-          <span class="secondary-text"> 用于将TG动态贴纸从视频格式转为GIF，在此处下载：<a class="link" data-href="https://ffmpeg.org/">FFmpeg</a></span>
+          <span class="secondary-text">
+            用于将TG动态贴纸从视频格式转为GIF，在此处下载：<a class="link" data-href="https://ffmpeg.org/">FFmpeg</a></span
+          >
         </div>
       </li>
       <li class="select-default-file-path vertical-list-item">
@@ -1150,7 +1159,11 @@
       <li class="vertical-list-item">
         <div>
           <h2>TGS转GIF程序路径地址</h2>
-          <span class="secondary-text"> 用于将TGS格式贴纸转为GIF，在此处下载：<a class="link" data-href="https://github.com/jiongjiongJOJO/tgs_to_gif/releases/latest">tgs_to_gif</a></span>
+          <span class="secondary-text">
+            用于将TGS格式贴纸转为GIF，在此处下载：<a class="link" data-href="https://github.com/jiongjiongJOJO/tgs_to_gif/releases/latest"
+              >tgs_to_gif</a
+            ></span
+          >
         </div>
       </li>
       <li class="select-default-file-path vertical-list-item">

--- a/src/html/view.html
+++ b/src/html/view.html
@@ -692,7 +692,10 @@
             <strong>0</strong> 禁用<br />
             <strong>-1</strong> 无限制<br />
             <strong>-2</strong> 锁定当前排序<br />
-            <i>这里的说明可能不太通俗易懂，如果有更好的描述欢迎提: <a class="link" data-href="https://github.com/xiyuesaves/LiteLoaderQQNT-lite_tools/pulls">Pr</a></i>
+            <i
+              >这里的说明可能不太通俗易懂，如果有更好的描述欢迎提:
+              <a class="link" data-href="https://github.com/xiyuesaves/LiteLoaderQQNT-lite_tools/pulls">PR</a></i
+            >
           </span>
         </div>
         <div class="slot-input-box">
@@ -1138,8 +1141,8 @@
         <div>
           <h2>FFmpeg路径地址</h2>
           <span class="secondary-text">
-            用于将TG动态贴纸从视频格式转为GIF，在此处下载：<a class="link" data-href="https://ffmpeg.org/">FFmpeg</a></span
-          >
+            用于将TG动态贴纸从视频格式转为GIF，在此处下载：<a class="link" data-href="https://ffmpeg.org/">FFmpeg</a>
+          </span>
         </div>
       </li>
       <li class="select-default-file-path vertical-list-item">
@@ -1160,10 +1163,9 @@
         <div>
           <h2>TGS转GIF程序路径地址</h2>
           <span class="secondary-text">
-            用于将TGS格式贴纸转为GIF，在此处下载：<a class="link" data-href="https://github.com/jiongjiongJOJO/tgs_to_gif/releases/latest"
-              >tgs_to_gif</a
-            ></span
-          >
+            用于将TGS格式贴纸转为GIF，在此处下载：
+            <a class="link" data-href="https://github.com/jiongjiongJOJO/tgs_to_gif/releases/latest">tgs_to_gif</a>
+          </span>
         </div>
       </li>
       <li class="select-default-file-path vertical-list-item">

--- a/src/html/view.html
+++ b/src/html/view.html
@@ -685,6 +685,16 @@
       <hr class="horizontal-dividing-line" />
       <li class="vertical-list-item">
         <div>
+          <h2>最近使用分组前置</h2>
+          <span class="secondary-text recommend-num">将最近使用过的指定数量表情分组前置，-1为无限制，0为关闭功能（默认关闭）</span>
+        </div>
+        <div class="slot-input-box">
+          <input placeholder="0" class="slot-input recent-folders-num text_color" type="number" spellcheck="false" />
+        </div>
+      </li>
+      <hr class="horizontal-dividing-line" />
+      <li class="vertical-list-item">
+        <div>
           <h2>快捷输入表情</h2>
           <span class="secondary-text">通过输入"/"唤起浮动表情列表，通过文件名进行筛选</span>
         </div>

--- a/src/main_modules/localEmoticons.js
+++ b/src/main_modules/localEmoticons.js
@@ -339,11 +339,16 @@ ipcMain.on("LiteLoader.lite_tools.addCommonlyEmoticons", (_, src) => {
 });
 // 更新最近使用分组
 ipcMain.on("LiteLoader.lite_tools.updateRecentFolders", (_, src) => {
+  // 固定当前排序
+  if (config.localEmoticons.recentlyNum === -2) {
+    return;
+  }
+
   // 更新recentFolders
   const folderPath = dirname(src);
 
   // 删除不存在的路径
-  localEmoticonsConfig.recentFolders = localEmoticonsConfig.recentFolders.filter(path => {
+  localEmoticonsConfig.recentFolders = localEmoticonsConfig.recentFolders.filter((path) => {
     const exists = existsSync(path);
     if (!exists) {
       log(`路径不存在，已移除: ${path}`);

--- a/src/main_modules/localEmoticons.js
+++ b/src/main_modules/localEmoticons.js
@@ -341,7 +341,6 @@ ipcMain.on("LiteLoader.lite_tools.addCommonlyEmoticons", (_, src) => {
 ipcMain.on("LiteLoader.lite_tools.updateRecentFolders", (_, src) => {
   // 更新recentFolders
   const folderPath = dirname(src);
-  const index = localEmoticonsConfig.recentFolders.indexOf(folderPath);
 
   // 删除不存在的路径
   localEmoticonsConfig.recentFolders = localEmoticonsConfig.recentFolders.filter(path => {
@@ -352,6 +351,7 @@ ipcMain.on("LiteLoader.lite_tools.updateRecentFolders", (_, src) => {
     return exists;
   });
 
+  const index = localEmoticonsConfig.recentFolders.indexOf(folderPath);
   if (index !== -1) {
     localEmoticonsConfig.recentFolders.splice(index, 1);
   }

--- a/src/main_modules/localEmoticons.js
+++ b/src/main_modules/localEmoticons.js
@@ -104,6 +104,9 @@ onUpdateConfig(async () => {
     }
     localEmoticonsConfig = require(localEmoticonsConfigPath);
     log("读取常用表情列表数据", localEmoticonsConfigPath, localEmoticonsConfig);
+    if (!localEmoticonsConfig.recentFolders) {
+      localEmoticonsConfig.recentFolders = [];
+    }
   }
 
   // 动态更新本地表情文件夹
@@ -150,6 +153,14 @@ onUpdateConfig(async () => {
       writeFileSync(localEmoticonsConfigPath, JSON.stringify(localEmoticonsConfig, null, 4));
     }
     oldCommonlyNum = config.localEmoticons.commonlyNum;
+  }
+
+  // 动态更新最近使用分组的数量
+  if (config.localEmoticons.recentlyNum >= 0 && localEmoticonsConfig.recentFolders.length > config.localEmoticons.recentlyNum) {
+    localEmoticonsConfig.recentFolders = localEmoticonsConfig.recentFolders.slice(0, config.localEmoticons.recentlyNum);
+    globalBroadcast("LiteLoader.lite_tools.updateEmoticons", emoticonsList);
+    log("更新最近使用分组数量", localEmoticonsConfigPath, localEmoticonsConfig);
+    writeFileSync(localEmoticonsConfigPath, JSON.stringify(localEmoticonsConfig, null, 4));
   }
 });
 
@@ -326,7 +337,35 @@ ipcMain.on("LiteLoader.lite_tools.addCommonlyEmoticons", (_, src) => {
   log("常用表情列表", localEmoticonsConfigPath, localEmoticonsConfig);
   writeFileSync(localEmoticonsConfigPath, JSON.stringify(localEmoticonsConfig, null, 4));
 });
+// 更新最近使用分组
+ipcMain.on("LiteLoader.lite_tools.updateRecentFolders", (_, src) => {
+  // 更新recentFolders
+  const folderPath = dirname(src);
+  const index = localEmoticonsConfig.recentFolders.indexOf(folderPath);
 
+  // 删除不存在的路径
+  localEmoticonsConfig.recentFolders = localEmoticonsConfig.recentFolders.filter(path => {
+    const exists = existsSync(path);
+    if (!exists) {
+      log(`路径不存在，已移除: ${path}`);
+    }
+    return exists;
+  });
+
+  if (index !== -1) {
+    localEmoticonsConfig.recentFolders.splice(index, 1);
+  }
+  localEmoticonsConfig.recentFolders.unshift(folderPath);
+
+  // 删除多余的值
+  const maxRecentFolders = config.localEmoticons.recentlyNum;
+  if (maxRecentFolders >= 0 && localEmoticonsConfig.recentFolders.length > maxRecentFolders) {
+    localEmoticonsConfig.recentFolders = localEmoticonsConfig.recentFolders.slice(0, maxRecentFolders);
+  }
+
+  log("最近使用分组", localEmoticonsConfigPath, localEmoticonsConfig);
+  writeFileSync(localEmoticonsConfigPath, JSON.stringify(localEmoticonsConfig, null, 4));
+});
 // 从历史记录中移除指定文件
 ipcMain.on("LiteLoader.lite_tools.deleteCommonlyEmoticons", (_, localPath) => {
   const newSet = new Set(localEmoticonsConfig.commonlyEmoticons);

--- a/src/pages/configView.js
+++ b/src/pages/configView.js
@@ -411,6 +411,15 @@ async function onConfigView(view) {
   addSwitchEventlistener("localEmoticons.commonlyEmoticons", ".switchCommonlyEmoticons", (_, enabled) => {
     view.querySelector(".hoverShowCommonlyEmoticons").classList.toggle("disabled-switch", !enabled);
   });
+  //最近使用分组数量
+  view.querySelector(".recent-folders-num").value = options.localEmoticons.recentlyNum;
+  view.querySelector(".recent-folders-num").addEventListener("blur", (e) => {
+    const newRecentFoldersNum = parseInt(e.target.value);
+    options.localEmoticons.recentlyNum = Number.isNaN(newRecentFoldersNum) ? 0 : newRecentFoldersNum;
+
+    e.target.value = options.localEmoticons.recentlyNum;
+    debounceSetOptions();
+  });
 
   // 初始化背景路径选择监听和值
   view.querySelector(".select-background-wallpaper-clear").value = options.background.url;

--- a/src/pages/configView.js
+++ b/src/pages/configView.js
@@ -415,8 +415,11 @@ async function onConfigView(view) {
   view.querySelector(".recent-folders-num").value = options.localEmoticons.recentlyNum;
   view.querySelector(".recent-folders-num").addEventListener("blur", (e) => {
     const newRecentFoldersNum = parseInt(e.target.value);
-    options.localEmoticons.recentlyNum = Number.isNaN(newRecentFoldersNum) ? 0 : newRecentFoldersNum;
-
+    let newValue = Number.isNaN(newRecentFoldersNum) ? 0 : newRecentFoldersNum;
+    if (newValue < -2) {
+      newValue = 0;
+    }
+    options.localEmoticons.recentlyNum = newValue;
     e.target.value = options.localEmoticons.recentlyNum;
     debounceSetOptions();
   });

--- a/src/preload.js
+++ b/src/preload.js
@@ -47,6 +47,8 @@ contextBridge.exposeInMainWorld("lite_tools", {
   log: (...args) => ipcRenderer.send("LiteLoader.lite_tools.log", ...args),
   // 更新常用表情列表
   addCommonlyEmoticons: (src) => ipcRenderer.send("LiteLoader.lite_tools.addCommonlyEmoticons", src),
+  // 更新更新最近使用分组
+  updateRecentFolders: (src) => ipcRenderer.send("LiteLoader.lite_tools.updateRecentFolders", src),
   // 获取窗口Id
   getWebContentId: () => ipcRenderer.sendSync("LiteLoader.lite_tools.getWebContentId"),
   // 打开文件路径

--- a/src/render_modules/options.js
+++ b/src/render_modules/options.js
@@ -31,6 +31,7 @@
  * @property {boolean} localEmoticons.toLeftSlot - 移动功能位置。
  * @property {boolean} localEmoticons.hoverShowCommonlyEmoticons - 悬停显示历史表情。
  * @property {number} localEmoticons.commonlyNum - 历史表情数量。
+ * @property {number} localEmoticons.recentlyNum - 最近使用分组数量。
  * @property {number} localEmoticons.rowsSize - 表情行数大小。
  * @property {string} localEmoticons.ffmpegPath - FFmpeg 路径。
  * @property {string} localEmoticons.tgBotToken - Telegram 机器人令牌。


### PR DESCRIPTION
为本地表情添加了最近使用分组前置功能

例如：现在有 `A B C D E F G H...Z`共26个分组
当我使用了C分组表情后，C分组会在分组表情列表中提前
本地表情列表显示为：`常用表情 C A B D...Z`
再次使用H分组表情后，本地表情列表顺序变为：
`常用表情 H C A B D...Z`
最近分组最多保留5个，其余的分组在后面还是会按照原本的顺序进行排列
例如我按照顺序从A到Z使用过每个分组的表情后，分组排列顺序将会变为
`常用表情 Z Y X W V A B C...`

主要是将自己平时惯用的表情包提前方便使用。
`recentFolders`的内容保存在了`localEmoticonsConfigTemplate.json`中。
上限目前写死为了常量`const maxRecentFolders = 5;`，这个按说应该是允许用户自行设置的，例如设置为-1时就是无上限，所有表情包全部都会按使用顺序排列，设置为0或者不设置时相当于关闭此功能，所有表情包都不会因为被使用而改变顺序。
但是我对LiteLoader的设置界面配置实在是一窍不通…所以只是实现了基本功能。

在`updateOptions`的时候可能也需要额外地处理一下`recentFolders`的内容，此外，由于不清楚到底哪个广播可以触发下方的表情分组列表更新，我直接在`insertToEditor`时进行`updateRecentFolders`并广播了`LiteLoader.lite_tools.updateEmoticons`。如果这里有问题的话也要麻烦您改一下了（

